### PR TITLE
edit misleading log message in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ class SendWelcomeEmailIfNeededJob
 
   def perform(customer_id)
     TraceId.reset! do |old_trace_id|
-      Rails.logger.info "Changing trace id from '#{old_trace_id}' to '#{trace_id}'"
+      Rails.logger.info "Changing trace id from '#{old_trace_id}' to '#{trace_id}' in job for Customer #{customer_id}"
     end
     Rails.logger.info "[#{trace_id}] perform(#{customer_id})"
     customer = Customer.find(customer_id)
@@ -198,10 +198,10 @@ Now the logs look like so:
 [original-trace-id] queuing job for active Customer 2
 [original-trace-id] queuing job for active Customer 3
 [original-trace-id] queuing job for active Customer 4
-Changing trace id from 'original-trace-id' to 'new-trace-id-1'
-Changing trace id from 'original-trace-id' to 'new-trace-id-2'
-Changing trace id from 'original-trace-id' to 'new-trace-id-3'
-Changing trace id from 'original-trace-id' to 'new-trace-id-4'
+Changing trace id from 'original-trace-id' to 'new-trace-id-1' in job for Customer 1
+Changing trace id from 'original-trace-id' to 'new-trace-id-2' in job for Customer 2
+Changing trace id from 'original-trace-id' to 'new-trace-id-3' in job for Customer 3
+Changing trace id from 'original-trace-id' to 'new-trace-id-4' in job for Customer 4
 [new-trace-id-1] perform(1)
 [new-trace-id-2] perform(2)
 [new-trace-id-3] perform(3)
@@ -223,16 +223,16 @@ If you want to understand what happened for Customer 4, you'd first search for `
 [original-trace-id] queuing job for active Customer 2
 [original-trace-id] queuing job for active Customer 3
 [original-trace-id] queuing job for active Customer 4
-Changing trace id from 'original-trace-id' to 'new-trace-id-1'
-Changing trace id from 'original-trace-id' to 'new-trace-id-2'
-Changing trace id from 'original-trace-id' to 'new-trace-id-3'
-Changing trace id from 'original-trace-id' to 'new-trace-id-4'
+Changing trace id from 'original-trace-id' to 'new-trace-id-1' in job for Customer 1
+Changing trace id from 'original-trace-id' to 'new-trace-id-2' in job for Customer 2
+Changing trace id from 'original-trace-id' to 'new-trace-id-3' in job for Customer 3
+Changing trace id from 'original-trace-id' to 'new-trace-id-4' in job for Customer 4
 ```
 
 You can see that for Customer 4 the trace id was changed to `new-trace-id-4`, which if you search for shows you:
 
 ```
-Changing trace id from 'original-trace-id' to 'new-trace-id-4'
+Changing trace id from 'original-trace-id' to 'new-trace-id-4' in job for Customer 4
 [new-trace-id-4] perform(4)
 [new-trace-id-4] checking Customer 4
 [new-trace-id-4] Sending Customer 4 the welcome email


### PR DESCRIPTION
The README has a nice example of why and when the user would want to use `reset!`, but your choice of placeholder data created a misleading example.

> You can see that for Customer 4 the trace id was changed to `new-trace-id-4`

This is not the case! I realize you probably deliberately chose to obscure this detail with your placeholder data, or were thinking that in reality you’d use your `log_message` gem to include this kind of info (good call not introducing it here!). But I felt compelled to PR this because I have seen so so so much time lost to assumptions like “the job that was queued fourth produced the fourth line in the log” and the example is about using `reset!` to avoid exactly this kind of confusion.
